### PR TITLE
fix path and json issues

### DIFF
--- a/template/src/service/app.js
+++ b/template/src/service/app.js
@@ -22,9 +22,9 @@ if (config.mode === 'dev') {
   const staticFolder = path.resolve(__dirname, './webapp/static')
   app.use('/static', express.static(staticFolder))
   app.get('/', function (req, res) {
-    res.sendFile(path.resolve(__dirname, './webapp/index.html'))
+    res.sendFile(path.resolve(__dirname, '../webapp/index.html'))
   })
-  app.use(favicon(path.resolve(__dirname, './webapp/static/favicon.ico')))
+  app.use(favicon(path.resolve(__dirname, '../webapp/static/favicon.ico')))
 }
 
 // Controllers

--- a/template/src/service/conf/config.js
+++ b/template/src/service/conf/config.js
@@ -5,7 +5,7 @@ let config = {}
 
 try {
   const yamlContent = yaml.safeLoad(fs.readFileSync(path.resolve(__dirname, 'default.yml'), 'utf8'))
-  config = JSON.stringify(yamlContent, null, 2)
+  config = JSON.parse(JSON.stringify(yamlContent, null, 2))
 } catch (e) {
   console.log(e)
 }


### PR DESCRIPTION
Found two issues when playing with the API service
1. Path in `app.js` is wrong
2. In `config.js`, `JSON.stringnify` returns a string. It should be parsed first to an object.